### PR TITLE
Only stamp task IDs on checkboxes that have a due date

### DIFF
--- a/src/tasks/TokenController.ts
+++ b/src/tasks/TokenController.ts
@@ -786,6 +786,14 @@ export class TokenController {
                 return '';
             }
 
+            // Only stamp tasks the calendar sync can actually use - without a
+            // due date there is nothing to schedule, and stamping every
+            // checkbox in the vault litters non-task lists with IDs
+            if (!/📅\s*\d{4}-\d{2}-\d{2}/u.test(line.text)) {
+                LogUtils.debug('Checkbox has no due date, skipping ID stamp');
+                return '';
+            }
+
             // Create the task ID
             const taskId = `<!-- task-id: ${id} -->`;
 


### PR DESCRIPTION
## Problem

The ID stamper marks every checkbox in the vault, including plain checklists (packing lists, shopping lists) that can never sync to a calendar because they carry no date. Those lines end up littered with `<!-- task-id -->` comments for nothing.

## Fix

Require a `📅 YYYY-MM-DD` due date on the line before stamping an ID in `_generateTaskId`. Checkboxes without one are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)