### PR TITLE
Add configurable Calendar ID setting (default: primary)

### DIFF
--- a/src/calendar/calendarSync.ts
+++ b/src/calendar/calendarSync.ts
@@ -68,6 +68,13 @@ export class CalendarSync {
     }
 
     /**
+     * Gets the calendar ID from settings, defaulting to 'primary'
+     */
+    private getCalendarId(): string {
+        return this.plugin.settings.calendarId || 'primary';
+    }
+
+    /**
      * Clears the events cache to force fresh data on next request
      */
     private clearEventsCache(): void {
@@ -81,7 +88,7 @@ export class CalendarSync {
     public async initialize(): Promise<void> {
         try {
             // Verify calendar access by making a test request
-            await this.makeRequest('/calendars/primary/events', 'GET', { maxResults: 1 });
+            await this.makeRequest(`/calendars/${this.getCalendarId()}/events`, 'GET', { maxResults: 1 });
 
             // Initialize repair manager if needed
             if (!this.plugin.repairManager) {
@@ -191,7 +198,7 @@ export class CalendarSync {
         const operation = async () => {
             try {
                 await this.checkRateLimit();
-                await this.makeRequest(`/calendars/primary/events/${eventId}`, 'DELETE');
+                await this.makeRequest(`/calendars/${this.getCalendarId()}/events/${eventId}`, 'DELETE');
                 LogUtils.debug(`Successfully deleted event: ${eventId}`);
             } catch (error) {
                 // If the event is already gone (410) or not found (404), consider it a success
@@ -235,7 +242,7 @@ export class CalendarSync {
                 }
 
                 const event = this.createEventFromTask(task);
-                await this.makeRequest(`/calendars/primary/events/${eventId}`, 'PUT', event);
+                await this.makeRequest(`/calendars/${this.getCalendarId()}/events/${eventId}`, 'PUT', event);
                 LogUtils.debug(`Updated event ${eventId} for task ${task.id}`);
 
                 const updatedMetadata = {
@@ -392,7 +399,7 @@ export class CalendarSync {
                 if (metadata?.eventId && !task.completed) {
                     try {
                         const event = this.createEventFromTask(task);
-                        await this.makeRequest(`/calendars/primary/events/${metadata.eventId}`, 'PUT', event);
+                        await this.makeRequest(`/calendars/${this.getCalendarId()}/events/${metadata.eventId}`, 'PUT', event);
                         this.updateTaskMetadata(task, metadata.eventId, metadata);
                         await this.saveSettings();
                         LogUtils.debug(`Updated existing event ${metadata.eventId} for task ${task.id} (via metadata fast path)`);
@@ -460,7 +467,7 @@ export class CalendarSync {
 
                     // Update the kept event
                     const event = this.createEventFromTask(task);
-                    await this.makeRequest(`/calendars/primary/events/${keepEvent.id}`, 'PUT', event);
+                    await this.makeRequest(`/calendars/${this.getCalendarId()}/events/${keepEvent.id}`, 'PUT', event);
                     this.updateTaskMetadata(task, keepEvent.id, metadata);
                     await this.saveSettings();
                     LogUtils.debug(`Updated existing event ${keepEvent.id} for task ${task.id}`);
@@ -785,7 +792,7 @@ export class CalendarSync {
             if (timeMin) params.timeMin = timeMin;
             if (timeMax) params.timeMax = timeMax;
 
-            const response = await this.makeRequest('/calendars/primary/events', 'GET', params);
+            const response = await this.makeRequest(`/calendars/${this.getCalendarId()}/events`, 'GET', params);
             const events = response.items || [];
 
             // Update cache with detailed logging
@@ -819,13 +826,13 @@ export class CalendarSync {
                     LogUtils.debug(`Using existing event ${existingEventId} for task ${task.id}`);
                     // Update the existing event instead of creating a new one
                     const event = this.createEventFromTask(task);
-                    await this.makeRequest(`/calendars/primary/events/${existingEventId}`, 'PUT', event);
+                    await this.makeRequest(`/calendars/${this.getCalendarId()}/events/${existingEventId}`, 'PUT', event);
                     return existingEventId;
                 }
 
                 // Create new event only if we don't have a valid existing one
                 const event = this.createEventFromTask(task);
-                const response = await this.makeRequest('/calendars/primary/events', 'POST', event);
+                const response = await this.makeRequest(`/calendars/${this.getCalendarId()}/events`, 'POST', event);
                 if (!response.id) {
                     throw new Error('Failed to create event: no event ID returned');
                 }
@@ -924,7 +931,7 @@ export class CalendarSync {
     public async listEvents(): Promise<GoogleCalendarEvent[]> {
         try {
             await this.checkRateLimit();
-            const response = await this.makeRequest('/calendars/primary/events', 'GET');
+            const response = await this.makeRequest(`/calendars/${this.getCalendarId()}/events`, 'GET');
             return response.items || [];
         } catch (error) {
             LogUtils.error('Failed to list calendar events:', error);

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: GoogleCalendarSettings = {
     clientSecret: '',
     oauth2Tokens: undefined,
     syncEnabled: true,
+    calendarId: 'primary',
     defaultReminder: 30,
     includeFolders: [],  // Empty by default to scan all folders
     taskMetadata: {},
@@ -65,6 +66,18 @@ export class GoogleCalendarSettingsTab extends PluginSettingTab {
 
         // Calendar Settings Section
         containerEl.createEl('h3', { text: 'Calendar Settings' });
+
+        new Setting(containerEl)
+            .setName('Calendar ID')
+            .setDesc('The Google Calendar to sync with. Use "primary" for your main calendar, or enter a specific calendar ID (found in calendar settings \u2192 "Integrate calendar")')
+            .addText(text => text
+                .setPlaceholder('primary')
+                .setValue(this.plugin.settings.calendarId || 'primary')
+                .onChange(async (value) => {
+                    this.plugin.settings.calendarId = value.trim() || 'primary';
+                    await this.plugin.saveSettings();
+                    new Notice(`Calendar ID updated to: ${this.plugin.settings.calendarId}`);
+                }));
 
         new Setting(containerEl)
             .setName('Default Reminder')

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -65,6 +65,7 @@ export interface GoogleCalendarSettings {
     encryptedOAuth2Tokens?: string; // Encrypted tokens (replaces oauth2Tokens when encrypted)
     tokensEncrypted?: boolean; // Flag indicating tokens are stored encrypted
     syncEnabled: boolean;
+    calendarId?: string; // Google Calendar to sync with; defaults to 'primary'
     defaultReminder: number;
     includeFolders: string[];
     taskMetadata: Record<string, TaskMetadata>;


### PR DESCRIPTION
## Problem

Every Google Calendar API call hardcodes `/calendars/primary/...`, so tasks can only sync to the account's main calendar. Anyone who wants task events on a dedicated or shared calendar (e.g. a `...@group.calendar.google.com` id) can't.

## Fix

- New `calendarId` setting (default `"primary"`, so behavior is unchanged for existing users), editable via a text field under **Calendar Settings** in the settings tab.
- `getCalendarId()` helper in `CalendarSync`, used by all 9 calendar API call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)